### PR TITLE
Resolve TODO: Compute w-Range on Client to Reduce Data Transfer

### DIFF
--- a/backend/__tests__/src/test_calculateSpectrum.py
+++ b/backend/__tests__/src/test_calculateSpectrum.py
@@ -13,4 +13,9 @@ def test_calc_spectrum():
     assert "y" in data
     assert "units" in data
 
+    assert isinstance(data["x"], dict)
+    assert "min" in data["x"]
+    assert "max" in data["x"]
+    assert "step" in data["x"]
+    assert "resample" in data["x"]
 

--- a/backend/src/routes/calculateSpectrum.py
+++ b/backend/src/routes/calculateSpectrum.py
@@ -33,22 +33,34 @@ async def calc_spectrum(payload: Payload):
         # to remove the nan values from x and y
         x = xNan[~np.isnan(xNan)]
         y = yNan[~np.isnan(yNan)]
+
+        # to compute X  on the client side.
+        x_min, x_max = x[0], x[-1]
+        if len(x) > 1:
+            x_step = x[1] - x[0]
+        else:
+            x_step = None
+        resample = None
+
         # Reduce payload size
         threshold = 5e7
         if len(spectrum) * 8 * 2 > threshold:
             print("Reducing the payload size")
             # Setting return payload size limit of 50 MB
             # one float is about 8 bytes
-            # we return 2 arrays (w, I)
-            #     (note: we could avoid returning the full w-range, and recompute it on the client
-            #     from the x min, max and step --> less data transfer. TODO )
+            # we return only one array (I), while the other one (W) is computed on the client side.
             resample = int(len(spectrum) * 8 * 2 // threshold)
-            x, y = x[::resample], y[::resample]
+            y = y[::resample]
 
         return {
             "data": {
-                "x": list(x),
                 "y": list(y),
+                "x":{
+                "min" : x_min,
+                "max" : x_max,
+                "step" : x_step,
+                "resample" :resample,
+                },
                 "units": spectrum.units[payload.mode],
             },
         }

--- a/frontend/src/components/Form.tsx
+++ b/frontend/src/components/Form.tsx
@@ -8,6 +8,7 @@ import ReactGA from "react-ga4";
 import { PlotSettings, Spectrum } from "../constants";
 import { formSchema } from "../modules/form-schema";
 import useFromStore from "../store/form";
+import computeX from "../utils/computeX";
 import { Database as DatabaseField } from "./fields/Database";
 import { Mode } from "./fields/Mode";
 import { TGas } from "./fields/TGas";
@@ -176,6 +177,19 @@ export const Form: React.FunctionComponent<FormProps> = ({
           handleBadResponse(response.error);
           setDisableDownloadButton(true);
         } else {
+          const x = computeX(
+            response.data.x.min,
+            response.data.x.max,
+            response.data.x.step,
+            response.data.x.resample
+          );
+
+          const formattedData = {
+            x: x,
+            y: response.data.y,
+            units: response.data.units,
+          };
+
           setSpectra([
             ...(appendSpectrum ? spectra : []),
             {
@@ -187,7 +201,7 @@ export const Form: React.FunctionComponent<FormProps> = ({
               pressure: data.pressure,
               pressure_units: data.pressure_units,
               wavelength_units: data.wavelength_units,
-              ...response.data,
+              ...formattedData,
             },
           ]);
           setDisableAddToPlotButton(false);

--- a/frontend/src/utils/computeX.ts
+++ b/frontend/src/utils/computeX.ts
@@ -1,0 +1,20 @@
+export default function computeX(
+  x_min: number,
+  x_max: number,
+  x_step: number,
+  resample: number
+): number[] {
+  let x: number[] = [];
+  for (let i = x_min; i <= x_max; i += x_step) {
+    x.push(i);
+  }
+
+  if (resample) {
+    console.log("Reducing the payload size");
+    // If y is resampled, x also get resampled.
+
+    x = x.filter((_, index) => index % resample === 0);
+  }
+
+  return x;
+}


### PR DESCRIPTION
Removed the need to return the full w-range by allowing the client to compute it using x min, max, and step values, reducing data transfer. Updated test_calc_spectrum to align with the new computation approach. This resolves a previously noted TODO.