### PR TITLE
fix: wavelength grid to show nm range correctly

### DIFF
--- a/backend/src/routes/calculateSpectrum.py
+++ b/backend/src/routes/calculateSpectrum.py
@@ -30,6 +30,10 @@ async def calc_spectrum(payload: Payload):
         wunit = spectrum.get_waveunit()
         iunit = "default"
         xNan, yNan = spectrum.get(payload.mode, wunit=wunit, Iunit=iunit)
+        # if the specified units were nm, convert the spectrum range (cm-1 by default) to nm
+        if (payload.wavelength_units == 'u.nm'):
+            xNan = 1e7 / xNan
+            xNan = np.sort(xNan)
         # to remove the nan values from x and y
         x = xNan[~np.isnan(xNan)]
         y = yNan[~np.isnan(yNan)]


### PR DESCRIPTION
This PR addresses the issue #679 .  

Earlier, selecting "nm" as the units for wavelength range generated the correct spectrum but the "x-range" in the plot grid showed "cm-1" range. Upon investigation, I found that the `radis.calculate_spectrum()` always returns the spectrum in "cm-1" range and hence, it is necessary to convert the obtained values to "nm" if user selected "nm" range. 

Before: 

<img width="1397" alt="Before" src="https://github.com/user-attachments/assets/740b3adc-479b-4a1a-b535-398e22aea6f5" />



After:

<img width="1397" alt="After" src="https://github.com/user-attachments/assets/9a45850a-bd6d-4b2e-9a8c-71ab599ad847" />
