### PR TITLE
fix: proper enabling/disabling of add to plot button

### DIFF
--- a/frontend/src/components/Form.tsx
+++ b/frontend/src/components/Form.tsx
@@ -99,21 +99,26 @@ export const Form: React.FunctionComponent<FormProps> = ({
       setUseSimulateSlitFunction(true);
       setValue("simulate_slit", 5);
     }
-    setDisableAddToPlotButton(true);
   }, [modeWatch]);
 
-  //if spectrum data more than 1 than we disabble the add to plot button if user interact with wavelength unit field
+  //if spectrum data more than 1 than we disable the add to plot button if user interact with wavelength unit or mode field
+  const ModeIsDirtyField = dirtyFields.mode;
   const WaveLengthUnitIsDirtyField = dirtyFields.wavelength_units;
   const wavelengthUnitWatch = watch("wavelength_units");
   React.useEffect(() => {
     if (spectra.length > 0) {
-      if (dirtyFields.wavelength_units === true) {
+      if (WaveLengthUnitIsDirtyField || ModeIsDirtyField) {
         setDisableAddToPlotButton(true);
       } else {
         setDisableAddToPlotButton(false);
       }
     }
-  }, [WaveLengthUnitIsDirtyField, spectra.length, wavelengthUnitWatch]);
+  }, [
+    WaveLengthUnitIsDirtyField,
+    ModeIsDirtyField,
+    spectra.length,
+    wavelengthUnitWatch,
+  ]);
 
   console.log(wavelengthUnitWatch);
   React.useEffect(() => {
@@ -190,6 +195,8 @@ export const Form: React.FunctionComponent<FormProps> = ({
               ...response.data,
             },
           ]);
+          dirtyFields.wavelength_units = false;
+          dirtyFields.mode = false;
           setDisableAddToPlotButton(false);
           setPlotSettings({
             mode: data.mode,


### PR DESCRIPTION
This PR addresses the issue #680 

The Add To Plot button now gets enabled on first calculation of a spectra. It also properly disables on changing wavelength units or mode. Also, it remains enabled if the molecule is changed without changing the wavelength units or mode.

https://github.com/user-attachments/assets/b74274d1-7513-486d-93fc-a184785f1d9b

