### PR TITLE
fix: download spec file when multiple molecules selected

### DIFF
--- a/backend/src/routes/downloadSpectrum.py
+++ b/backend/src/routes/downloadSpectrum.py
@@ -14,7 +14,7 @@ async def download_spec(payload: Payload, background_tasks: BackgroundTasks):
     try:
         create_download_directory(DOWNLOADED_SPECFILES_DIRECTORY)
         spectrum = calculate_spectrum(payload)
-        file_name_spec = spectrum.get_name()
+        file_name_spec = '_'.join(spectrum.get_name().split('//'))
         file_name = f"{file_name_spec}.spec"
         file_path = f"{DOWNLOADED_SPECFILES_DIRECTORY}/{file_name}"
         if payload.use_simulate_slit is True:


### PR DESCRIPTION
Currently, if we select multiple molecules for generating a spectrum, the spec file for it cannot be downloaded. This is because of the erroneous file name generated at the backend.

<img width="927" alt="Screenshot 2025-03-22 at 11 05 03 AM" src="https://github.com/user-attachments/assets/038ee0a6-29a8-4439-9289-3288ffadaae3" />

Proper file naming has been implemented to allow downloads of spec files when selecting multiple molecules.

Before : 

https://github.com/user-attachments/assets/8c29fc9c-3269-4873-b3a3-855cbc3f241f

After :

https://github.com/user-attachments/assets/53a2eb02-dd6c-4ed3-8aee-afb7506792cb

