### PR TITLE
feat: set proper image download name

### DIFF
--- a/frontend/src/components/Plot.tsx
+++ b/frontend/src/components/Plot.tsx
@@ -130,6 +130,11 @@ export const Plot_: React.FC<PlotProps> = ({
     }
     return formatted;
   };
+  const generateFileName = (spectra: Spectrum[]) =>
+    `${spectra
+      .map((s) => s.species.map((specie) => specie.molecule).join("_"))
+      .join("_")}_${spectra[0].database}`;
+
   return (
     <Plotly
       className="Plot"
@@ -186,6 +191,11 @@ export const Plot_: React.FC<PlotProps> = ({
         updatemenus,
         showlegend: true,
         legend: { orientation: "h", y: -0.6, x: 0 },
+      }}
+      config={{
+        toImageButtonOptions: {
+          filename: generateFileName(spectra),
+        },
       }}
     />
   );


### PR DESCRIPTION
This PR resolves #733 

The image is now downloaded with proper file name generated based on the plotted spectra details.


https://github.com/user-attachments/assets/2c94739c-0939-454e-a42e-f4e5930c2330

