### PR TITLE
Add exomol and nist databases

### DIFF
--- a/backend/radis_scripts/download_exomol.py
+++ b/backend/radis_scripts/download_exomol.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+"""
+Download some molecules from EXOMOL data, parse & cache them, to make 
+sure the example notebooks run fast.
+"""
+
+from radis.io.exomol import fetch_exomol
+
+# More molecules will be confirmed and added in upcoming updates
+EXOMOL_working_molecules = [
+    'CO',
+    'NO',
+    'AlO', 
+    'HCl',
+]
+
+for molecule in EXOMOL_working_molecules:
+    fetch_exomol(molecule)

--- a/backend/src/helpers/calculateSpectrum.py
+++ b/backend/src/helpers/calculateSpectrum.py
@@ -3,6 +3,13 @@ import astropy.units as u
 from  astropy.units import cds 
 from src.models.payload import Payload
 
+# An arbitrary broadening formula as NIST databank requires `lbfunc`
+def broad_arbitrary(**kwargs):
+    """An arbitrary broadening formula for the Lorentzian component"""
+    HWHM = kwargs["pressure_atm"] * (296 / kwargs["Tgas"]) ** 0.7
+    shift = None
+    return HWHM, shift
+
 def calculate_spectrum(payload: Payload):
     print(">> Payload : ")
     print(payload)
@@ -14,7 +21,7 @@ def calculate_spectrum(payload: Payload):
             species.molecule: species.mole_fraction for species in payload.species
         },
         # TODO: Hard-coding "1,2,3" as the isotopologue for the time-being
-        isotope={species.molecule: "1,2,3" for species in payload.species},
+        isotope={species.molecule: "1,2,3" for species in payload.species} if payload.database != "nist" else 0,
         pressure=payload.pressure * eval(payload.pressure_units),
         Tgas=payload.tgas,
         Tvib=payload.tvib,
@@ -24,5 +31,8 @@ def calculate_spectrum(payload: Payload):
         wstep="auto",
         databank=payload.database,
         use_cached=True,
+        lbfunc = broad_arbitrary if payload.database == "nist" else None,
+        # TODO: add nist and kurucz as options here
+        # pfsource=payload.database if payload.database == "nist" else None,
     )
     return spectrum

--- a/backend/src/models/payload.py
+++ b/backend/src/models/payload.py
@@ -21,7 +21,7 @@ class Payload(BaseModel):
         "transmittance",
         "radiance",
     ]
-    database: Literal["hitran", "geisa", "hitemp"]
+    database: Literal["hitran", "geisa", "hitemp", "exomol", "nist"]
     wavelength_units: Literal["1/u.cm", "u.nm"]
     pressure_units: Literal["u.bar", "u.mbar", "cds.atm", "u.torr", "u.mTorr", "u.Pa"]
     path_length_units: Literal["u.cm", "u.m", "u.km"]


### PR DESCRIPTION
This PR adds ExoMol and NIST databases to the backend.

To test ExoMol:
```json
{

"min_wavenumber_range": 1900,

"max_wavenumber_range": 2300,

"species": [

{

"molecule": "CO",

"mole_fraction": 0.1

}

],

"pressure": 1.01325,

"tgas": 300,

"tvib": null,

"trot": null,

"path_length": 1.0,

"use_simulate_slit": false,

"mode": "radiance_noslit", 

"database": "exomol", 

"wavelength_units": "1/u.cm", 

"pressure_units": "u.bar", 

"path_length_units": "u.cm" 

}
```

For the NIST one, it gave this error:
```bash
nist DBFORMAT -------------------------- [MY-HITEMP-CO2] # your databank name: use this in calc_spectrum() # or SpectrumFactory.load_databank() info = HITEMP 2010 databank # whatever you want path = # no "", multipath allowed D:\Databases\HITEMP-CO2\hitemp_07 D:\Databases\HITEMP-CO2\hitemp_08 D:\Databases\HITEMP-CO2\hitemp_09 format = hitran # 'hitran' (HITRAN/HITEMP), 'cdsd-hitemp', 'cdsd-4000' # databank text file format. More info in # SpectrumFactory.load_databank function. parfuncfmt: # 'cdsd', 'hapi', etc. # format to read tabulated partition function # file. If `hapi`, then HAPI (HITRAN Python # interface) is used to retrieve them (valid if # your databank is HITRAN data). HAPI is embedded # into RADIS. Check the version. # Optional # ---------- parfunc: # path to tabulated partition function to use. # If `parfuncfmt` is `hapi` then `parfunc` # should be the link to the hapi.py file. If # not given, then the hapi.py embedded in RADIS # is used (check version) levels_iso1 # path to energy levels (needed for non-eq # calculations). Default None levels_iso2 # etc levels_iso4 # etc levelsfmt: # 'cdsd', etc. # how to read the previous file. Default None. levelsZPE: # zero-point-energy (cm-1): offset for all level # energies. Default 0 (if not given) -------------------------- No databank named nist in `/home/mohy/radis.json`. Available databanks: ['HITRAN-CH4', 'GEISA-CH4', 'HITEMP-CH4', 'HITEMP-OH', 'HITEMP-OH-TEST-ENGINE-PYTABLES', 'HITEMP-OH-TEST-PARTIAL-LOADING', 'HITEMP-OH-2010', 'HITEMP-CO-2010', 'HITEMP-CO', 'HITRAN-CO2-TEST', 'HITRAN-CO-TEST', 'HITEMP-CO2-TEST', 'HITEMP-CO2-HAMIL-TEST', 'HITRAN-CO', 'HITRAN-CO2', 'GEISA-OH', 'GEISA-CO', 'HITEMP-H2O-2010', 'HITRAN-NO', 'HITRAN-C2H2', 'HITRAN-C2H4', 'HITRAN-C2H6', 'HITRAN-H2O', 'NIST-O_I', 'NIST-Be_I', 'NIST-N_II', 'Kurucz-Y_I', 'Kurucz-Os_II', 'NIST-Y_V', 'NIST-N_I', 'Kurucz-N_II']. See databank format above. More information in https://radis.readthedocs.io/en/latest/lbl/lbl.html#configuration-file
```

But it was resolved after updating RADIS to the latest version:
```bash
pip install --upgrade radis
```
Also, another error related to pandas was raised:
```bash
No such keys(s): 'future.no_silent_downcasting'
```
So I upgraded pandas:
```bash
pip install --upgrade pandas
```

After that, this atomic example should work fine:
```json
{

"min_wavenumber_range": 9679,

"max_wavenumber_range": 20074,

"species": [

{

"molecule": "N_II",

"mole_fraction": 0.1

}

],

"pressure": 20,

"tgas": 9000,

"tvib": null,

"trot": null,

"path_length": 1.0,

"use_simulate_slit": false,

"mode": "radiance_noslit", 

"database": "nist",

"wavelength_units": "1/u.cm", 

"pressure_units": "u.bar", 

"path_length_units": "u.cm" 

}

```

fix #740 