### PR TITLE
fixed the weird background around error toasts

### DIFF
--- a/frontend/src/components/ErrorAlert.tsx
+++ b/frontend/src/components/ErrorAlert.tsx
@@ -14,6 +14,11 @@ export const ErrorAlert: React.FC<ErrorAlertInterface> = ({ message }) => {
       open={open}
       onClose={() => setOpen(false)}
       key={message}
+      sx={{
+        background: "transparent",
+        boxShadow: "none",
+        border: "none",
+      }}
     >
       <Alert color="danger">{message}</Alert>
     </Snackbar>


### PR DESCRIPTION
before:
![image](https://github.com/user-attachments/assets/cf4a2d1c-f238-417f-b6ad-5d69a1ff5a66)


after :
![image](https://github.com/user-attachments/assets/750fb517-1dc1-4d54-b00c-846136e516b1)
