### PR TITLE
fix: update wavelength unit handling in download_txt function

### DIFF
--- a/backend/src/routes/downloadTxt.py
+++ b/backend/src/routes/downloadTxt.py
@@ -29,7 +29,11 @@ async def download_txt(payload: Payload, background_tasks: BackgroundTasks):
         return {"error": str(exc)}
     else:
         
-        wunit = spectrum.get_waveunit()
+        wunit = "cm-1"
+        if(payload.wavelength_units=="1/u.cm"):
+            wunit="cm-1"
+        else:
+            wunit="nm"
         iunit = "default"
         spectrum.savetxt(file_path,payload.mode,wunit=wunit,Iunit=iunit)
         # running as a background task to delete the .spec file after giving the file response back


### PR DESCRIPTION
I think we should stick with saving only one spectrum to .txt, since we can use it with the load_spec API from the RADIS package, and also for fitting either through the RADIS app or via code.
This PR fixes the units problem that was mentioned: previously, the data always appeared in cm⁻¹, even when the user computed the spectrum in nm.

fix #723 