### PR TITLE
fix: conditionally set slit parameter in experimental conditions

### DIFF
--- a/backend/src/helpers/fitSpectrum.py
+++ b/backend/src/helpers/fitSpectrum.py
@@ -61,10 +61,13 @@ async def fit_spectrum(payload: Payload, file: UploadFile):
         # "lbfunc": broad_arbitrary if ExperimentalConditions.database == "nist" else None,
         # "cutoff": 0,  # (RADIS native) Discard linestrengths that are lower that this to reduce calculation time, in cm-1.
         # "slit": f"{ExperimentalConditions.simulate_slit} {slit_unit}",  # Experimental slit, must be a blank space separating slit amount and unit.
-        "slit": f"{ExperimentalConditions.simulate_slit} nm",  # Experimental slit, must be a blank space separating slit amount and unit.
-        "offset": "-0.2 nm",
+        # "slit": f"{ExperimentalConditions.simulate_slit} nm",  # Experimental slit, must be a blank space separating slit amount and unit.
+        # "offset": "-0.2 nm",
         "databank": ExperimentalConditions.database,  # Databank used for calculation. Must be stated.
     }
+
+    if ExperimentalConditions.use_simulate_slit:
+        experimental_conditions["slit"] = f"{ExperimentalConditions.simulate_slit} nm"
 
     # List of parameters to be fitted.
     fit_parameters = {}


### PR DESCRIPTION
conditionally set the slit parameter in experimental conditions when it's selected to prevent the bug below

#761

<img width="1767" height="1090" alt="image" src="https://github.com/user-attachments/assets/f47c63bd-bb63-41dc-a940-0692c21641ff" />
