### PR TITLE
fix path length and pressure validation rejecting values below 1

### DIFF
--- a/frontend/__tests__/src/modules/form-schema.test.tsx
+++ b/frontend/__tests__/src/modules/form-schema.test.tsx
@@ -50,6 +50,32 @@ describe("Form Schema Module", () => {
         }
     });
 
+    const spectrumData = {
+        pressure: 1,
+        tgas: 300,
+        path_length: 1,
+        min_wavenumber_range: 1900,
+        max_wavenumber_range: 2300,
+        species: [{ molecule: "CO2", mole_fraction: 0.1 }],
+    };
+
+    it("accepts path length and pressure below 1", async () => {
+        const { formSchema } = await import("../../../src/modules/form-schema");
+
+        const data = { ...spectrumData, path_length: 0.1, pressure: 0.1 };
+
+        await expect(formSchema.validate(data)).resolves.toBeDefined();
+    });
+
+    it("rejects zero and negative path length and pressure", async () => {
+        const { formSchema } = await import("../../../src/modules/form-schema");
+
+        await expect(formSchema.validate({ ...spectrumData, path_length: 0 })).rejects.toThrow();
+        await expect(formSchema.validate({ ...spectrumData, path_length: -1 })).rejects.toThrow();
+        await expect(formSchema.validate({ ...spectrumData, pressure: 0 })).rejects.toThrow();
+        await expect(formSchema.validate({ ...spectrumData, pressure: -1 })).rejects.toThrow();
+    });
+
     it("validates field requirements", async () => {
         const { formSchema } = await import("../../../src/modules/form-schema");
 

--- a/frontend/src/modules/form-schema.ts
+++ b/frontend/src/modules/form-schema.ts
@@ -7,12 +7,12 @@ export const formSchema = yup.object().shape({
     .number()
     .required("Path length must be defined")
     .typeError("Path length must be defined")
-    .min(1, "Path length cannot be negative"),
+    .positive("Path length must be positive"),
   pressure: yup
     .number()
     .required("Pressure must be defined")
     .typeError("Pressure must be defined")
-    .min(1, "Pressure cannot be negative"),
+    .positive("Pressure must be positive"),
   tgas: yup
     .number()
     .required("Tgas must be defined")
@@ -169,7 +169,7 @@ export const formSchemaFit = yup.object().shape({
           .number()
           .required("Pressure must be defined")
           .typeError("Pressure must be defined")
-          .min(0.1, "Pressure must be positive"),
+          .positive("Pressure must be positive"),
       }),
   }),
   experimental_conditions: yup.object().shape({
@@ -200,12 +200,12 @@ export const formSchemaFit = yup.object().shape({
       .number()
       .required("Pressure must be defined")
       .typeError("Pressure must be defined")
-      .min(1, "Pressure cannot be negative"),
+      .positive("Pressure must be positive"),
     path_length: yup
       .number()
       .required("Path length must be defined")
       .typeError("Path length must be defined")
-      .min(1, "Path length cannot be negative"),
+      .positive("Path length must be positive"),
     simulate_slit: yup.number().nullable(),
     use_simulate_slit: yup.boolean().required().default(false),
     wavelength_units: yup.string().required(),


### PR DESCRIPTION
`path_length` and `pressure` were validated with `.min(1, "... cannot be negative")`,
so entering 0.1 cm was refused with a "cannot be negative" error. The bound should be
 0, not >= 1, the backend already accepts any value `gt=0`.

Replaced the wrong bound with yup's `.positive()` for path length and pressure, in both
the spectrum form and the fit form, and fixed the error messages to match. Added a test
for sub-1 values.

fixes https://github.com/radis/radis/issues/1015